### PR TITLE
Allow whitespaces in a section name.

### DIFF
--- a/src/grammar.lisp
+++ b/src/grammar.lisp
@@ -68,7 +68,7 @@
         #+esrap.function-terminals name-component-separator/expression))
 
 (defrule name-component
-    (+ (or quoted (not (or comment whitespace
+    (+ (or quoted (not (or comment
                            name-component-separator
                            #\[ #\]
                            assignment-operator))))

--- a/src/grammar.lisp
+++ b/src/grammar.lisp
@@ -68,7 +68,7 @@
         #+esrap.function-terminals name-component-separator/expression))
 
 (defrule name-component
-    (+ (or quoted (not (or comment
+    (+ (or quoted (not (or comment whitespace
                            name-component-separator
                            #\[ #\]
                            assignment-operator))))
@@ -80,10 +80,23 @@
   (:destructure (first rest)
     (cons first (mapcar #'second rest))))
 
+(defrule section-name-component
+    (+ (or quoted (not (or comment
+                           name-component-separator
+                           #\[ #\]
+                           assignment-operator))))
+  (:text t))
+
+(defrule section-name
+    (and section-name-component
+         (* (and name-component-separator section-name-component)))
+  (:destructure (first rest)
+    (cons first (mapcar #'second rest))))
+
 ;; Sections
 
 (defrule section
-    (and #\[ name #\])
+    (and #\[ section-name #\])
   (:destructure (open name close &bounds start end)
     (declare (ignore open close))
     (list :section (list name (cons start end)))))


### PR DESCRIPTION
Section name can contain whitespaces.
This is an example of `~/.aws/config` which is used by AWS CLI:

```
[default]
output = json
region = ap-northeast-1

[profile nproject]
role_arn = arn:aws:iam::xxxxxxxxxx:role/admin
source_profile = default
region = ap-northeast-1
```